### PR TITLE
Feature/post Image 업로드 가능한 최대 파일 크기 수정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ cloud.aws.credentials.secretKey=
 cloud.aws.s3.bucket=uanditripbucket
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket.url=[arn:aws:s3:::uanditripbucket]
+# Image Upload Max Size
+spring.servlet.multipart.maxFileSize=50MB
+spring.servlet.multipart.maxRequestSize=50MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,4 @@ cloud.aws.s3.bucket.url=[arn:aws:s3:::uanditripbucket]
 # Image Upload Max Size
 spring.servlet.multipart.maxFileSize=50MB
 spring.servlet.multipart.maxRequestSize=50MB
+


### PR DESCRIPTION
이미지가 1MB정도만 업로드가 가능하기에 크기를 지정하는 코드를 추가 했습니다.

```
# Image Upload Max Size
spring.servlet.multipart.maxFileSize=50MB
spring.servlet.multipart.maxRequestSize=50MB
```